### PR TITLE
Fixes to fundamental tag and add tag to style guide

### DIFF
--- a/content/en/code-review.md
+++ b/content/en/code-review.md
@@ -2,7 +2,7 @@
 title: Code Review
 status: Completed
 category: concept
-tags: ["fundamentals", "", ""]
+tags: ["fundamental", "", ""]
 ---
 
 Code review is a software quality assurance activity in which one or more people examine the source code of a computer program.

--- a/content/en/code-scanning.md
+++ b/content/en/code-scanning.md
@@ -2,7 +2,7 @@
 title: Code Scanning
 status: Completed
 category: concept
-tags: ["fundamentals", "", ""]
+tags: ["fundamental", "", ""]
 ---
 
 Code scanning is the process of using tools to analyze the source code of a computer program for potential security flaws, bugs, and other issues.

--- a/content/en/style-guide/_index.md
+++ b/content/en/style-guide/_index.md
@@ -90,6 +90,7 @@ An exception to this is the `fundamental` tag, which indicates this term is need
 
 The current tags are:
 
+- acronym
 - attack
 - defense
 - vulnerability


### PR DESCRIPTION
Minor updates to correct fundamental tag in a couple of terms, and add acronym as an available tag to style guide.
    
