### PR TITLE
Switch "buffer overflow" definition to NIST's

### DIFF
--- a/content/en/buffer-overflow.md
+++ b/content/en/buffer-overflow.md
@@ -5,6 +5,6 @@ category: concept
 tags: ["vulnerability", "", ""]
 ---
 
-The software copies an input buffer to an output buffer without verifying that the size of the input buffer is less than the size of the output buffer. It can lead to a denial of service or (in some cases) arbitrary code execution.
+A condition at an interface under which more input can be placed into a buffer or data holding area than the capacity allocated, overwriting other information. Adversaries exploit such a condition to crash a system or to insert specially crafted code that allows them to gain control of the system
 
-Source: https://cwe.mitre.org/data/definitions/120.html
+Source: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r3.pdf


### PR DESCRIPTION
The MITRE definition of "buffer overflow" is often used but it's not very good. The MITRE definition implies there's always an "input buffer" which isn't necessarily true.

Switch to the NIST definition for this circumstance, it's clearer.

### Describe your changes


### Related issue number or link (ex: `resolves #issue-number`)


### Checklist before opening this PR (put `x` in the checkboxes)
- [ ] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [ ] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
