### PR TITLE
Update contrib files to replace CNCF references

### DIFF
--- a/content/en/contribute/_index.md
+++ b/content/en/contribute/_index.md
@@ -15,30 +15,14 @@ There are a number of ways you can contribute to this project, which we'll cover
 1) [Work on an existing issue](#work-on-an-existing-issue)
 2) [Propose new terms](#propose-new-terms)
 3) [Update existing ones](#update-an-existing-term)
-4) [Localize the glossary](#help-localize-the-glossary)
 
-## CNCF glossary overview 
+## OpenSSF glossary overview 
 
 The goal of this glossary is to simplify the open source software security space and thus make it more accessible to people. 
 
 The OpenSSF Glossary content is stored in [this GitHub repo](https://github.com/ossf/glossary) 
 where you'll find a list of [issues](https://github.com/ossf/glossary/issues), pull requests ([PRs](https://github.com/ossf/glossary/pulls)), and 
 [discussions](https://github.com/ossf/glossary/discussions) about the glossary. 
-
-## Who can contribute?
-
-How you can participate in this project depends on your level of cloud native expertise. 
-Simplifying complex concepts requires a deep knowledge of the topic. 
-Therefore, to contribute new terms, you must be proficient in them. 
-Contributors are typically engineers who have worked with these technologies for some time or academics focused on cloud native. 
-
-That know-how is required because explaining complex concepts in simple words is _really_ hard. And while the digestible, user-friendly outcome may seem easy, achieving the desired simplicity results from hard work and collaboration between cloud native experts. 
-
-If you are not a cloud native expert yet but still want to contribute, we recommend teaming up with someone who is. 
-Once the expert is confident that the term accurately describes the concept, you are ready for your first Glossary contribution.
-
-The localization effort is where beginners proficient in another language can make valuable contributions to the Glossary. 
-With solid existing definitions in English, less experienced contributors can localize terms to a target language. You can join an existing localization team or create a new one. Read this guide's [Help Localize the glossary](#help-localize-the-glossary) section to learn how to get started. 
 
 ## Before you start
 
@@ -60,16 +44,14 @@ And when naming .md files, please use lowercase letters and hyphens instead of s
 
 Read our [Style Guide](/style-guide/) to understand our guidelines for formatting and writing documents and make the contribution process more efficient. 
 
-## Join the Glossary community! {#join-the-glossary-community}
+## Join the Best Practices community! {#join-the-glossary-community}
 
-If you want to contribute regularly, consider joining our monthly Glossary Working Group meetings. 
-You can find the meeting details in the [CNCF calendar](https://www.cncf.io/calendar/). 
-You can also connect with the maintainers and fellow contributors in our [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) channel on the CNCF Slack 
-— we'd love to meet you! 
+If you want to contribute regularly, consider joining our Best Practices for Open Source Developers Working Group meetings. 
+You can find the meeting details in the [OpenSSF calendar](https://openssf.org/getinvolved/).
 
 ## Work on an existing issue {#work-on-an-existing-issue}
 
-Go to the [Glossary GitHub repo issues](https://github.com/cncf/glossary/issues) to find a list of available issues. 
+Go to the [Glossary GitHub repo issues](https://github.com/ossf/glossary/issues) to find a list of available issues. 
 You can use labels (e.g., English language, help needed, good first issue) to filter out issues.
 
 ![Issue and labels](/images/how-to/issue-and-labels.png)
@@ -83,9 +65,6 @@ Once you select a term to work on, comment on the issue.
 
 ![Claiming an issue](/images/how-to/claiming-an-issue.png)
 
-Additionally, notify the maintainers on the [#glossary](https://cloud-native.slack.com/archives/C02TX20MQBB) channel of the CNCF Slack workspace and 
-tag _@iamnoah_, _@nate-double-u_, _@Seokho Son_, _@Jihoon Seo_, and/or _@castrojo_ to be sure they don't miss it.
-
 For the next steps, please refer to the [Submitting a new term (creating a PR)](#submitting-a-new-term) section.
 
 **Note**: you can start working on an issue after the maintainers assigned it to you. 
@@ -96,8 +75,6 @@ Workig on multiple terms is sequential, you must complete a term before claiming
 
 You can propose a new term for others to work on or create a new definition yourself. 
 Either way, you'll start by [creating an issue](#creating-an-issue). 
-To be added to the glossary, every new term must meet the [CNCF's cloud native definition](https://github.com/cncf/toc/blob/main/DEFINITION.md). 
-The only exceptions are foundational terms needed to understand cloud native concepts.
 
 Below is a step-by-step guide for people unfamiliar with GitHub. 
 **If you are a GitHub Pro**, please _do_ scan this guide to gather enough information about the following topics:
@@ -108,7 +85,7 @@ Below is a step-by-step guide for people unfamiliar with GitHub.
 
 ### Creating an issue {#creating-an-issue}
 
-Go to the [Glossary GitHub repo](https://github.com/cncf/glossary/issues) issues and click on "New issue".
+Go to the [Glossary GitHub repo](https://github.com/ossf/glossary/issues) issues and click on "New issue".
 
 ![issues](/images/how-to/howto-01.png)
 
@@ -125,7 +102,6 @@ Next, the maintainers will triage the issue.
 That means they will assess if the term should be part of the Glossary. 
 Not every term will be admitted. To be included in the Glossary, they should be established and widely-used cloud native concepts.
 
-Please let the maintainers know that you've proposed a new term on Slack and tag _@iamnoah_, _@nate-double-u_, _@Seokho Son_, _@Jihoon Seo_, and/or _@castrojo_ so that they don't miss it.
 If you want to work on the definition, let the maintainers know and they'll assign it to you.
 
 ### Submitting a new term (creating a PR) {#submitting-a-new-term}
@@ -179,8 +155,8 @@ or work on the changes yourself and submit a PR.
 
 ### Request a change via an issue {#request-a-change-via-an-issue}
 
-If you want to flag a problem with a term, you can use the "Report issue" option of the CNCF Glossary webpage. 
-Locate yourself in the CNCF page of the concept you'd like to flag and click on "Report issue". 
+If you want to flag a problem with a term, you can use the "Report issue" option of the OpenSSF Glossary webpage. 
+Locate yourself in the OpenSSF page of the concept you'd like to flag and click on "Report issue". 
 This will automatically open an issue for you
 
 ![report issue](/images/how-to/howto-14.png)
@@ -199,13 +175,6 @@ This will open the term's GitHub page. Make your changes and create a PR.
 Please refer to the [Best practices](#best-practices) section above 
 and read our [Style Guide](/style-guide/) to make sure you follow our guidelines. 
 
-## Help localize the glossary {#help-localize-the-glossary}
-
-To help localize the glossary into a target language, please join the [#glossary-localizations](https://cloud-native.slack.com/archives/C02N2RGFXDF) channel on the CNCF Slack workspace and send us a message.
-You can either join an existing team or create a new one 
-(to see what it takes, read our [Localization Guide](https://github.com/cncf/glossary/blob/main/LOCALIZATION.md)). 
-Please read the **How to contribute** guide of the target language to gather the specifics of that team's contribution process. 
-
 ## Spell check {#spell-check}
 
 There are two main reasons why the spell check can fail:
@@ -220,6 +189,5 @@ To add new words to the list, follow these steps:
 3. Add a commit message and select "Sign off and propose changes".
 
 **Note**: the spell check is case-insensitive. 
-
 
 **We updated this guide based on templates from [The Good Docs Project](https://thegooddocsproject.dev/).**

--- a/content/en/contributor-ladder/_index.md
+++ b/content/en/contributor-ladder/_index.md
@@ -7,31 +7,28 @@ menu:
     weight: 10
 ---
 
-Hi there! 👋 Thanks for your interest in contributing to the CNCF Cloud Native Glossary project. 
-Whether you contribute new terms, help localize the Glossary into your native language, 
-or want to help others get started, there are many ways to become an active member of this community. 
+Hi there! 👋 Thanks for your interest in contributing to the OpenSSF Glossary project. 
+Whether you contribute new terms or want to help others get started, there are many ways to become an active member of this community. 
 This doc outlines the different contributor roles within the project and the responsibilities and privileges that come with them.
 
 ## 1. Contributors
 
 The Glossary is for everyone. Anyone can become a Glossary contributor simply by contributing to the project. 
-All contributors are expected to follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+All contributors are expected to follow the [OpenSSF Code of Conduct](https://openssf.org/community/code-of-conduct/).
 
 There are a variety of ways you can contribute to the project, including:
 
 - **Content contributors**: everyone who improves existing terms or contributes new ones, 
-- **Localization contributors**: those who help translate the glossary into another language,
 - **Helpers**: anyone who helps others on GitHub, Slack, or wherever community members need support,
 - **Ambassadors**: anyone who helps spread the word, educates the community on how to contribute and why they should do so. 
 
 Contributors can have multiple roles or focus on one area only. 
 **All these contributions are equally important** and help foster a thriving community. 
-Please refer to the [How to Contribute](/contribute/) and [Style Guide](/style-guide/) for content and localization contributions.
+Please refer to the [How to Contribute](/contribute/) and [Style Guide](/style-guide/) for content contributions.
 
 ## 2. Approvers
 
 Approvers provide feedback on PRs and approve them. Any active contributor can become an approver (see [Becoming an approver](#becoming-an-approver)). 
-The Glossary differentiates between two approvers: (1) approvers for the English Glossary and (2) approvers for localization teams.
 
 Glossary approvers are expected to:
 
@@ -56,16 +53,9 @@ However, if they approve a PR on technical merit, they must ensure it is reviewe
 **Editors**: Editors proofread terms and ensure they are explained in simple language according to the Style Guide. 
 If a term is heavily edited, the editor must request a technical approver to review it again to ensure the meaning wasn't altered.
 
-### Localization Approvers
-
-The Glossary also has localization approvers. These are approvers for one of the localization teams (teams translating the glossary). 
-Localization approvers are only permitted to perform approver duties for their own team and have the ability to merge PRs to their dedicated development branch. 
-Any localization approver can also become an approver for the English Glossary if they meet the requirements. 
-
 ### Becoming an Approver
 
 Approver candidates should have a proven track record of submitting high-quality PRs and helping others get their PRs in a mergeable state. 
-If their timezone permits, they should also regularly attend the [Glossary Working Group meetings](https://www.cncf.io/calendar/).
 
 To become an approver, start by expressing interest to existing maintainers. 
 Existing maintainers will then ask you to demonstrate the qualifications above by contributing PRs, doing reviews, and doing other such tasks under their guidance. 
@@ -79,15 +69,15 @@ There are certain expectations for maintainers, including:
 
 - Be an active and responsive approver (see above),
 - Help maintain the repository, including site configuration, permission, issue-template, GitHub workflow, among others,
-- Monitor the Glossary Slack channels and help out whenever possible,
-- Regularly attend the [Glossary Working Group meetings](https://www.cncf.io/calendar/) (if timezone permits)
+- Monitor the OpenSSF Slack channels and help out whenever possible,
+- Regularly attend the [Best Practices Working Group meetings](https://www.openssf.org/getinvolved/) (if timezone permits)
 
 If a maintainer is no longer interested in or cannot perform the duties listed above, they should move themselves to emeritus status.
 
 ### Becoming a Maintainer
 
 Maintainers should have a proven track record of being successful approvers and submitting high-quality PRs. 
-If their timezone permits, they should also regularly attend the Glossary Working Group meetings.
+If their timezone permits, they should also regularly attend the Best Practices Working Group meetings.
 
 To become a maintainer, start by expressing interest to existing maintainers. 
 Existing maintainers will then ask you to demonstrate the qualifications above by contributing PRs, doing reviews, and doing other such tasks under their guidance. 


### PR DESCRIPTION
### Describe your changes

Updates contributing documentation to replace CNCF references with OpenSSF

### Related issue number or link (ex: `resolves #issue-number`)


### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
