### PR TITLE
Tweak definition of reproducible builds

### DIFF
--- a/content/en/reproducible-build.md
+++ b/content/en/reproducible-build.md
@@ -5,7 +5,7 @@ category: concept
 tags: ["fundamental", "", ""]
 ---
 
-A build is *reproducible* if given the same source code, build environment and build instructions, any party can recreate bit-by-bit identical copies of all specified artifacts. This creates an independently-verifiable path from source to binary code and counters attacks on the build process.
+A build is *reproducible* if given the same source code, any party can recreate bit-by-bit identical copies of all specified artifacts. Information about the build environment and build instructions is usually needed to achieve that. This creates an independently-verifiable path from source to binary code and counters attacks on the build process.
 
 A *verified* reproducible build is a build result that has been independently verified to reproduce. Verified reproducible builds allow multiple third parties to come to a consensus on a “correct” result, highlighting any deviations as suspect and worthy of scrutiny. See <https://reproducible-builds.org/docs/> for tips on how to achieve reproducible builds.
 


### PR DESCRIPTION
### Describe your changes

This relaxes the definition a bit around build environment.

https://lists.reproducible-builds.org/pipermail/rb-general/2025-April/003726.html

I'm opening a merge request on the proposed change for review and more discussion.

### Related issue number or link (ex: `resolves #issue-number`)


### Checklist before opening this PR (put `x` in the checkboxes)
- [X] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [X] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
