### PR TITLE
Update deployment to install pagefind for search functionality

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -36,6 +36,7 @@ jobs:
 
       - run: npm ci
       - run: hugo --baseURL https://glossary.openssf.org --minify
+      - run: npm_config_yes=true npx pagefind --site 'public' --output-subdir '../static/pagefind'
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
### Describe your changes
Search requires pagefind which needs to be installed during the deployment. This change adds that installation to the deployment action, based on its implementation in package.json.

### Related issue number or link (ex: `resolves #issue-number`)


### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
