### PR TITLE
Change output dir for pagefind in gh-pages

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -36,11 +36,10 @@ jobs:
 
       - run: npm ci
       - run: hugo --baseURL https://glossary.openssf.org --minify
-      - run: npm_config_yes=true npx pagefind --site 'public' --output-subdir '../static/pagefind'
+      - run: npm_config_yes=true npx pagefind --site 'public' --output-subdir 'pagefind'
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         if: ${{ github.ref == 'refs/heads/main' }} # <-- specify same branch as above here
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          allow_empty_commit: true


### PR DESCRIPTION
### Describe your changes
This change reverses the empty commit change for deployment and change the output dir for installation of pagefind. This should fix pagefind being installed outside of the public dir and then be seen by the gh-pages deployment.

### Related issue number or link (ex: `resolves #issue-number`)


### Checklist before opening this PR (put `x` in the checkboxes)
- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.
    
