### PR TITLE
Harden L10n workflows against branch-name script injection

### DIFF
--- a/.github/workflows/check-outdated-content.yaml
+++ b/.github/workflows/check-outdated-content.yaml
@@ -30,10 +30,12 @@ jobs:
     steps:
     - name: Set up environment variables for the target L10n team
       shell: bash
+      env:
+        BASE_REF: ${{ github.base_ref }}
       run: |
-        
+
         # Set L10n branch
-        L10N_BRANCH="${{github.base_ref}}"
+        L10N_BRANCH="${BASE_REF}"
         echo "(DEBUG) L10N Branch: ${L10N_BRANCH}"
         
         # Set output direcory
@@ -74,6 +76,10 @@ jobs:
     - name: Check outdated
       id: checker
       shell: bash
+      env:
+        REF: ${{ github.ref }}
+        HEAD_REF: ${{ github.head_ref }}
+        BASE_REF: ${{ github.base_ref }}
       run: |
         ##### DEBUG section, this will be removed later ###########
         ls -al
@@ -85,9 +91,9 @@ jobs:
         echo "Extract branch: ${GITHUB_REF#refs/}"
         
         # `github` context information
-        echo "(DEBUG) github.ref: ${{github.ref}}"
-        echo "(DEBUG) github.head_ref: ${{github.head_ref}}"
-        echo "(DEBUG) github.base_ref: ${{github.base_ref}}"
+        echo "(DEBUG) github.ref: ${REF}"
+        echo "(DEBUG) github.head_ref: ${HEAD_REF}"
+        echo "(DEBUG) github.base_ref: ${BASE_REF}"
         echo "(DEBUG) L10N_DIR: ${L10N_DIR}"
         echo "(DEBUG) L10N_DIR: ${{ env.L10N_DIR }}"
         #####################################################
@@ -99,7 +105,7 @@ jobs:
         
         # Get the old branch from 'github.base_ref' 
         # The old branch can be 'upstream/dev-ko'
-        OLD_BRANCH="origin/${{github.base_ref}}"
+        OLD_BRANCH="origin/${BASE_REF}"
         echo "(DEBUG) OLD_BRANCH: ${OLD_BRANCH}"
 
         L10N_INFO_JSON=$(cat <<EOF

--- a/.github/workflows/post-outdated-content-report.yaml
+++ b/.github/workflows/post-outdated-content-report.yaml
@@ -33,6 +33,13 @@ jobs:
         HEAD_REF: ${{ github.head_ref }}
         JOB: ${{ github.job }}
         REF: ${{ github.ref }}
+        REPOSITORY: ${{ github.repository }}
+        REPOSITORY_OWNER: ${{ github.repository_owner }}
+        RUN_ID: ${{ github.run_id }}
+        RUN_NUMBER: ${{ github.run_number }}
+        SHA: ${{ github.sha }}
+        WORKFLOW: ${{ github.workflow }}
+        WORKSPACE: ${{ github.workspace }}
       run: |
         echo "(DEBUG) ParsedBranch: ${GITHUB_REF#refs/heads/}"
         echo "(DEBUG) toJSON(github):"
@@ -46,14 +53,13 @@ jobs:
         echo "(DEBUG) github.head_ref: ${HEAD_REF}"
         echo "(DEBUG) github.job: ${JOB}"
         echo "(DEBUG) github.ref: ${REF}"
-        echo "(DEBUG) github.repository: ${{ github.repository }}"
-        echo "(DEBUG) github.repository_owner: ${{ github.repository_owner }}"
-        echo "(DEBUG) github.run_id: ${{ github.run_id }}"
-        echo "(DEBUG) github.run_number: ${{ github.run_number }}"
-        echo "(DEBUG) github.sha: ${{ github.sha }}"
-        echo "(DEBUG) github.token: ${{ github.token }}"
-        echo "(DEBUG) github.workflow: ${{ github.workflow }}"
-        echo "(DEBUG) github.workspace: ${{ github.workspace }}"
+        echo "(DEBUG) github.repository: ${REPOSITORY}"
+        echo "(DEBUG) github.repository_owner: ${REPOSITORY_OWNER}"
+        echo "(DEBUG) github.run_id: ${RUN_ID}"
+        echo "(DEBUG) github.run_number: ${RUN_NUMBER}"
+        echo "(DEBUG) github.sha: ${SHA}"
+        echo "(DEBUG) github.workflow: ${WORKFLOW}"
+        echo "(DEBUG) github.workspace: ${WORKSPACE}"
         
 #     NOTE - "actions/download-artifact" is not working for sharing data between workflows. 
 #     - name: Download output

--- a/.github/workflows/post-outdated-content-report.yaml
+++ b/.github/workflows/post-outdated-content-report.yaml
@@ -22,21 +22,30 @@ jobs:
     steps:    
     - name: Show the github context
       shell: bash
+      env:
+        GH_CONTEXT: ${{ toJSON(github) }}
+        ACTION: ${{ github.action }}
+        ACTION_PATH: ${{ github.action_path }}
+        ACTOR: ${{ github.actor }}
+        BASE_REF: ${{ github.base_ref }}
+        EVENT_NAME: ${{ github.event_name }}
+        EVENT_PATH: ${{ github.event_path }}
+        HEAD_REF: ${{ github.head_ref }}
+        JOB: ${{ github.job }}
+        REF: ${{ github.ref }}
       run: |
         echo "(DEBUG) ParsedBranch: ${GITHUB_REF#refs/heads/}"
-        echo "(DEBUG) github: ${{ github }}"
-        echo "(DEBUG) toJSON(github):" 
-        echo '${{ toJSON(github) }}'
-        echo "(DEBUG) github.action: ${{ github.action }}"
-        echo "(DEBUG) github.action_path: ${{ github.action_path }}"
-        echo "(DEBUG) github.actor: ${{ github.actor }}"
-        echo "(DEBUG) github.base_ref: ${{ github.base_ref	}}"
-        echo "(DEBUG) github.event: ${{ github.event }}"
-        echo "(DEBUG) github.event_name: ${{ github.event_name }}"
-        echo "(DEBUG) github.event_path: ${{ github.event_path }}"
-        echo "(DEBUG) github.head_ref: ${{ github.head_ref }}"
-        echo "(DEBUG) github.job: ${{ github.job }}"
-        echo "(DEBUG) github.ref: ${{ github.ref }}"
+        echo "(DEBUG) toJSON(github):"
+        echo "${GH_CONTEXT}"
+        echo "(DEBUG) github.action: ${ACTION}"
+        echo "(DEBUG) github.action_path: ${ACTION_PATH}"
+        echo "(DEBUG) github.actor: ${ACTOR}"
+        echo "(DEBUG) github.base_ref: ${BASE_REF}"
+        echo "(DEBUG) github.event_name: ${EVENT_NAME}"
+        echo "(DEBUG) github.event_path: ${EVENT_PATH}"
+        echo "(DEBUG) github.head_ref: ${HEAD_REF}"
+        echo "(DEBUG) github.job: ${JOB}"
+        echo "(DEBUG) github.ref: ${REF}"
         echo "(DEBUG) github.repository: ${{ github.repository }}"
         echo "(DEBUG) github.repository_owner: ${{ github.repository_owner }}"
         echo "(DEBUG) github.run_id: ${{ github.run_id }}"


### PR DESCRIPTION
## What

The two localization workflows reference branch-ref context values directly inside `run:` blocks:

- `check-outdated-content.yaml`: `${{ github.base_ref }}` and `${{ github.head_ref }}` appear in the bash steps, including `OLD_BRANCH="origin/${{github.base_ref}}"`, which is then used in `git diff ${OLD_BRANCH}..${LATEST_BRANCH}`.
- `post-outdated-content-report.yaml`: the debug step echoes `${{ github.head_ref }}`, `${{ github.base_ref }}`, and the raw `${{ github }}` context.

## Why this matters

`${{ }}` expressions are expanded into the script text by the Actions runner before bash runs, so a value an attacker can influence (a pull-request branch name) is concatenated straight into the command. A branch named something like `$(...)` can therefore execute arbitrary commands when the workflow runs. This is the script-injection pattern described in GitHub's [security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections), and it is what CodeQL's `actions/expression-injection` query and zizmor flag.

## The change

Each affected branch-ref value is now passed through a step-level `env:` block and referenced as a quoted shell variable (`"$HEAD_REF"`) inside `run:`. Environment variables are not re-parsed by the shell, so the untrusted text can no longer alter the script. I also routed the report workflow's context dump through `toJSON(github)` in `env:` rather than echoing the raw `${{ github }}` object.

No behavior changes: the same values are logged and the same git refs are compared.