### PR TITLE
Fix/tag routing

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -79,6 +79,7 @@ style = "tango"
 [params]
 copyright = "The Linux Foundation®"
 privacy_policy = "https://www.linuxfoundation.org/privacy"
+disqusShortname = ""
 
 # First one is picked as the Twitter card image if not set on page.
 images = ["images/openssf-glossary-social.jpg"]

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -22,9 +22,9 @@
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
 		<br />
 	{{ end }}
-	{{ if (.Site.DisqusShortname) }}
-		<br />
-		{{ partial "disqus-comment.html" . }}
+	{{ if .Site.Params.DisqusShortname }}
+    <br />
+    	{{ partial "disqus-comment.html" . }}
 	{{ end }}
 	{{ partial "page-meta-lastmod.html" . }}
 </div>

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -10,14 +10,15 @@
 
     <div class="canonical-tag-container">
         {{ range $tags }}
-            {{ $tagid := printf "tag-%s" ( replace .Page.Title " " "-" ) }}
+            {{ $tagid := printf "tag-%s" ( replace (lower .Page.Title) " " "-" ) }}
             <button id="{{ $tagid  }}" class="canonical-tag" data-target="{{ $tagid  }}">{{ title .Page.Title }}</button>
         {{ end }}
         <span><button class="button-reset-to-text" id="select-all-tags">{{ T "ui_select_all" }}</button></span>
         <span><button class="button-reset-to-text" id="deselect-all-tags">{{ T "ui_deselect_all" }}</button></span>
     </div>
     
-    {{ $glossary_items := (where .Site.Pages "Params.status" "Completed") | union (where .Site.Pages "Params.status" "completed") }}
+    {{ $glossary_items := where .Site.Pages "Params.status" "in" (slice "Completed" "completed") }}
+    
     {{ with $glossary_items }}
         {{ $glossary_terms := sort . "Title" "asc" }}
         <div id="terms-by-tag">
@@ -25,7 +26,7 @@
                 {{ $.Scratch.Set "tag_classes" "" }}
                 {{ range .Params.tags }}
                     {{ with . }}
-                        {{ $.Scratch.Add "tag_classes" (printf "tag-%s " ( replace . " " "-" ) )  }}
+                        {{ $.Scratch.Add "tag_classes" (printf "tag-%s " ( replace (lower .) " " "-" ) )  }}
                     {{ end }}
                 {{ end }}
                 
@@ -33,7 +34,7 @@
                     <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
                     <div>
                         <p>
-                        {{ replace ( .Summary | markdownify ) "What it is" "" }}..
+                            {{ ( replace ( .Summary | markdownify ) "What it is" "" ) | safeHTML }}..
                         </p>
                     </div>
                 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -297,6 +297,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -1630,6 +1631,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",

--- a/themes/docsy/layouts/docs/list.html
+++ b/themes/docsy/layouts/docs/list.html
@@ -23,7 +23,7 @@
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
 		<br />
 	{{ end }}
-	{{ if (.Site.DisqusShortname) }}
+	{{ if .Site.Params.DisqusShortname }}
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}

--- a/themes/docsy/layouts/partials/disqus-comment.html
+++ b/themes/docsy/layouts/partials/disqus-comment.html
@@ -1,23 +1,14 @@
+{{ if .Site.Params.DisqusShortname }}
 <div class="page-blank">
-
-<div id="disqus_thread"></div>
-<script>
-
-/**
-*  RECOMMENDED CONFIGURATION VARIABLES: EDIT AND UNCOMMENT THE SECTION BELOW TO INSERT DYNAMIC VALUES FROM YOUR PLATFORM OR CMS.
-*  LEARN WHY DEFINING THESE VARIABLES IS IMPORTANT: https://disqus.com/admin/universalcode/#configuration-variables*/
-/*
-var disqus_config = function () {
-this.page.url = PAGE_URL;  // Replace PAGE_URL with your page's canonical URL variable
-this.page.identifier = PAGE_IDENTIFIER; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
-};
-*/
-(function() { // DON'T EDIT BELOW THIS LINE
-var d = document, s = d.createElement('script');
-s.src = 'https://' + {{ .Site.DisqusShortname }} + '.disqus.com/embed.js';
-s.setAttribute('data-timestamp', +new Date());
-(d.head || d.body).appendChild(s);
-})();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+  <div id="disqus_thread"></div>
+  <script>
+    (function() {
+      var d = document, s = d.createElement('script');
+      s.src = 'https://' + {{ .Site.Params.DisqusShortname }} + '.disqus.com/embed.js';
+      s.setAttribute('data-timestamp', +new Date());
+      (d.head || d.body).appendChild(s);
+    })();
+  </script>
+  <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 </div>
+{{ end }}

--- a/themes/docsy/layouts/swagger/list.html
+++ b/themes/docsy/layouts/swagger/list.html
@@ -23,7 +23,7 @@
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
 		<br />
 	{{ end }}
-	{{ if (.Site.DisqusShortname) }}
+	{{ if .Site.Params.DisqusShortname }}
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}


### PR DESCRIPTION
### Describe your changes

This PR resolves several issues identified during site building:

* **Tag Routing:** Fixed a casing mismatch in `terms.html` by normalizing tag IDs and CSS classes to lowercase. This ensures the filter logic correctly matches items with their assigned tags.
* **HTML Rendering:** Added `| safeHTML` to the summary rendering pipeline in `terms.html` to prevent embedded HTML tags (like `<p>`, `<ul>`, `<li>`) from being escaped and displayed as plain text.
* **Build Stability:** Updated deprecated `.Site.DisqusShortname` calls (which were causing build errors in newer Hugo versions) to the safe `.Site.Params.DisqusShortname` syntax across all project layouts and vendored theme partials. Added an `if` guard to the Disqus partial to prevent build failures when `disqusShortname` is empty.
* **YAML Correction:** Fixed a minor YAML parsing error in `content/en/rule.md` that was preventing successful site assembly.

### Related issue number or link

resolves #66

### Checklist before opening this PR (put `x` in the checkboxes)

- [x] This PR does not contain plagiarism
  - don’t copy other people’s work unless you are quoting and contributing it to them.
- [x] I have signed off on all commits 
  - [signing off](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (ex: `git commit -s`) is to affirm that commits comply [DCO](https://wiki.linuxfoundation.org/dco). If you are working locally, you could add an alias to your `gitconfig` by running `git config --global alias.ci "commit -s"`.